### PR TITLE
Remove http and https

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,6 +1,4 @@
 const fs = require('fs');
-const http = require('http');
-const https = require('https');
 const express = require('express');
 const Cache = require('node-cache');
 const cors = require('cors');
@@ -9,16 +7,7 @@ const keybaseClient = require('./keybase-client');
 
 const CHANNEL = 'grincoin#general';
 const HTTP_PORT = process.env.HTTP_PORT;
-const HTTPS_PORT = process.env.HTTPS_PORT;
-const privkey = fs.readFileSync(process.env.PRIVKEY_PATH);
-const fullchain = fs.readFileSync(process.env.FULLCHAIN_PATH);
-const credentials = {
-  key: privkey,
-  cert: fullchain,
-};
 const app = express().set('json spaces', 2);
-const httpServer = http.createServer(app);
-const httpsServer = https.createServer(credentials, app);
 const cache = new Cache();
 
 function midCache(key, duration) {
@@ -51,13 +40,6 @@ app.get('/team', cors(), midCache('grincoin.public', 86400), (req, res) => {
   });
 });
 
-if (HTTP_PORT) {
-  httpServer.listen(HTTP_PORT, () => {
-    console.log(`[info]: Starting http server on: ${HTTP_PORT}`);
-  });
-}
-if (HTTPS_PORT) {
-  httpsServer.listen(HTTPS_PORT, () => {
-    console.log(`[info]: Starting https server on: ${HTTPS_PORT}`);
-  });
-}
+app.listen(HTTP_PORT ,() => {
+  console.log(`[info]: Starting http server on: ${HTTP_PORT}`);
+});


### PR DESCRIPTION
Removes Node.js' packages for handling SSL.
Server is now behind an Nginx reverse proxy instead with automatic Let's Encrypt renewal.

Resolves https://github.com/mimblewimble/site/issues/224.